### PR TITLE
Changed SSL parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ddn auth login
 
 ### Step 2: Configure the connector
 
-After the supergraph and subgraph have been initialized (refer to [Prerequisites](#Prerequisites), run the initialization command in interactive mode. Specify a name for the connector in the command.
+After the supergraph and subgraph have been initialized (refer to [Prerequisites](#Prerequisites)), run the initialization command in interactive mode. Specify a name for the connector in the command.
 
 ```bash
 ddn connector init <connector-name>  -i

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Alternatively, you can also set following environment variables instead of the `
 | SINGLESTORE_USER                    |             | SingleStore user to authenticate as. |
 | SINGLESTORE_PASSWORD                |             | Password of the SingleStore database user. |
 | SINGLESTORE_DATABASE                |             | Name of the SingleStore database to connect with. |
-| SINGLESTORE_SSL_CA                  |             | Name of the environment variable that stores the CA certificates. |
-| SINGLESTORE_SSL_CERT                |             | Name of the environment variable that stores the cert chain in PEM format. |
-| SINGLESTORE_SSL_KEY                 |             | Name of the environment variable that stores the private key in PEM format. |
+| SINGLESTORE_SSL_CA                  |             | CA certificate. |
+| SINGLESTORE_SSL_CERT                |             | Certificate chain in PEM format. |
+| SINGLESTORE_SSL_KEY                 |             | Private key in PEM format. |
 | SINGLESTORE_SSL_CIPHERS             |             | Cipher suite specification. If specified, it replaces the default value. |
 | SINGLESTORE_SSL_PASSPHRASE          |             | Shared passphrase used for a single private key. |
 | SINGLESTORE_SSL_REJECT_UNAUTHORIZED | true        | If enabled, the server rejects any connection that is not authorized with the list of supplied CAs. |

--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ Alternatively, you can also set following environment variables instead of the `
 |-------------------------------------|-------------|-------------|
 | SINGLESTORE_HOST                    | localhost   | Hostname of the SingleStore database to connect with. |
 | SINGLESTORE_PORT                    | 3306        | Port number of the SingleStore database. |
+| SINGLESTORE_USER                    |             | SingleStore user to authenticate as. |
 | SINGLESTORE_PASSWORD                |             | Password of the SingleStore database user. |
 | SINGLESTORE_DATABASE                |             | Name of the SingleStore database to connect with. |
-| SINGLESTORE_SSL_CA                  |             | Path to the trusted CA certificate file. |
-| SINGLESTORE_SSL_CERT                |             | Path to the certificate chain file in PEM format. |
-| SINGLESTORE_SSL_KEY                 |             | Path to the private key file in PEM format. |
+| SINGLESTORE_SSL_CA                  |             | Name of the environment variable that stores the CA certificates. |
+| SINGLESTORE_SSL_CERT                |             | Name of the environment variable that stores the cert chain in PEM format. |
+| SINGLESTORE_SSL_KEY                 |             | Name of the environment variable that stores the private key in PEM format. |
 | SINGLESTORE_SSL_CIPHERS             |             | Cipher suite specification. If specified, it replaces the default value. |
-| SINGLESTORE_SSL_PASSPHRASE          |             | Cipher suite specification. If specified, it replaces the default value. |
+| SINGLESTORE_SSL_PASSPHRASE          |             | Shared passphrase used for a single private key. |
 | SINGLESTORE_SSL_REJECT_UNAUTHORIZED | true        | If enabled, the server rejects any connection that is not authorized with the list of supplied CAs. |
 
 If `SINGLELSTORE_URL` is set these variables are ignored.

--- a/connector-definition/connector-metadata.yaml
+++ b/connector-definition/connector-metadata.yaml
@@ -14,12 +14,6 @@ supportedEnvironmentVariables:
     description: Password of the SingleStore database user.
   - name: SINGLESTORE_DATABASE
     description: Name of the SingleStore database to connect with.
-  - name: SINGLESTORE_SSL_CA
-    description: Name of the environment variable that stores the CA certificates.
-  - name: SINGLESTORE_SSL_CERT
-    description: Name of the environment variable that stores the cert chain in PEM format.
-  - name: SINGLESTORE_SSL_KEY
-    description: Name of the environment variable that stores the private key in PEM format.
   - name: SINGLESTORE_SSL_CIPHERS
     description: Cipher suite specification.  If specified, it replaces the default value.
   - name: SINGLESTORE_SSL_PASSPHRASE

--- a/connector-definition/connector-metadata.yaml
+++ b/connector-definition/connector-metadata.yaml
@@ -3,29 +3,29 @@ packagingDefinition:
   dockerImage: ghcr.io/singlestore-labs/singlestore-hasura-connector:v0.0.3
 supportedEnvironmentVariables:
   - name: SINGELSTORE_URL
-    description: The url for the SingleStore database. The format is `mysql://[<user>[:<password>]][@<host>:[<port>]]/[<database>][?<key1>=<value1>[&<key2>=<value2>]]`.
+    description: URL for the SingleStore database. The format is `mysql://[<user>[:<password>]][@<host>:[<port>]]/[<database>][?<key1>=<value1>[&<key2>=<value2>]]`.
   - name: SINGLESTORE_HOST
-    description: The hostname of the database you are connecting to. (default - localhost)
+    description: Hostname of the SingleStore database to connect with. (default - localhost)
   - name: SINGLESTORE_PORT
-    description: The port number to connect to. (default - 3306)
+    description: Port number of the SingleStore database. (default - 3306)
   - name: SINGLESTORE_USER
-    description: The SingleStore user to authenticate as
+    description: SingleStore user to authenticate as.
   - name: SINGLESTORE_PASSWORD
-    description: The password of that SingleStore user
+    description: Password of the SingleStore database user.
   - name: SINGLESTORE_DATABASE
-    description: The name of the database to use
+    description: Name of the SingleStore database to connect with.
   - name: SINGLESTORE_SSL_CA
-    description: The path to trusted CA certificates file
+    description: Name of the environment variable that stores the CA certificates.
   - name: SINGLESTORE_SSL_CERT
-    description: The path to cert chain file in PEM format
+    description: Name of the environment variable that stores the cert chain in PEM format.
   - name: SINGLESTORE_SSL_KEY
-    description: The path to private key file in PEM format
+    description: Name of the environment variable that stores the private key in PEM format.
   - name: SINGLESTORE_SSL_CIPHERS
-    description: The cipher suite specification, replacing the default
+    description: Cipher suite specification.  If specified, it replaces the default value.
   - name: SINGLESTORE_SSL_PASSPHRASE
-    description: The shared passphrase used for a single private key
+    description: Shared passphrase used for a single private key.
   - name: SINGLESTORE_SSL_REJECT_UNAUTHORIZED
-    description: If true the server will reject any connection which is not authorized with the list of supplied CAs (default true)
+    description: If enabled, the server rejects any connection that is not authorized with the list of supplied CAs. (default - true)
 commands:
   update:
     type: Dockerized

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,9 +33,9 @@ export function createPool(): Pool {
             password: SINGLESTORE_PASSWORD,
             database: SINGLESTORE_DATABASE,
             ssl: (SINGLESTORE_SSL_CA || SINGLESTORE_SSL_CERT || SINGLESTORE_SSL_CIPHERS || SINGLESTORE_SSL_KEY || SINGLESTORE_SSL_PASSPHRASE || SINGLESTORE_SSL_REJECT_UNAUTHORIZED) ? {
-                ca: SINGLESTORE_SSL_CA ? readFileSync(SINGLESTORE_SSL_CA) : undefined,
-                cert: SINGLESTORE_SSL_CERT ? readFileSync(SINGLESTORE_SSL_CERT) : undefined,
-                key: SINGLESTORE_SSL_KEY ? readFileSync(SINGLESTORE_SSL_KEY) : undefined,
+                ca: SINGLESTORE_SSL_CA ? process.env[SINGLESTORE_SSL_CA] : undefined,
+                cert: SINGLESTORE_SSL_CERT ? process.env[SINGLESTORE_SSL_CERT] : undefined,
+                key: SINGLESTORE_SSL_KEY ? process.env[SINGLESTORE_SSL_KEY] : undefined,
                 ciphers: SINGLESTORE_SSL_CIPHERS,
                 passphrase: SINGLESTORE_SSL_PASSPHRASE,
                 rejectUnauthorized: Boolean(SINGLESTORE_SSL_REJECT_UNAUTHORIZED)

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,9 +33,9 @@ export function createPool(): Pool {
             password: SINGLESTORE_PASSWORD,
             database: SINGLESTORE_DATABASE,
             ssl: (SINGLESTORE_SSL_CA || SINGLESTORE_SSL_CERT || SINGLESTORE_SSL_CIPHERS || SINGLESTORE_SSL_KEY || SINGLESTORE_SSL_PASSPHRASE || SINGLESTORE_SSL_REJECT_UNAUTHORIZED) ? {
-                ca: SINGLESTORE_SSL_CA ? process.env[SINGLESTORE_SSL_CA] : undefined,
-                cert: SINGLESTORE_SSL_CERT ? process.env[SINGLESTORE_SSL_CERT] : undefined,
-                key: SINGLESTORE_SSL_KEY ? process.env[SINGLESTORE_SSL_KEY] : undefined,
+                ca: SINGLESTORE_SSL_CA,
+                cert: SINGLESTORE_SSL_CERT,
+                key: SINGLESTORE_SSL_KEY,
                 ciphers: SINGLESTORE_SSL_CIPHERS,
                 passphrase: SINGLESTORE_SSL_PASSPHRASE,
                 rejectUnauthorized: Boolean(SINGLESTORE_SSL_REJECT_UNAUTHORIZED)


### PR DESCRIPTION
Previously SSL parameters took file paths.
Hasura starts the connector in the docker container, so this approach didn't work.
Now SSL parameters take the name of the actual content of certificates.
The same approach is used in the Postgres connector.